### PR TITLE
Create background jobs on application startup

### DIFF
--- a/config/initializers/create_background_jobs.rb
+++ b/config/initializers/create_background_jobs.rb
@@ -1,0 +1,4 @@
+# Create all Rufus Scheduler Jobs for active checks on Application Start
+Check.active.each do |check|
+  check.create_job
+end


### PR DESCRIPTION
Since all Checks are Scheduled using Rufus Scheduler they are only scheduled in memory and lost on Application restart.

This Pull Request introduces an Initializer that recreates all Background Jobs automatically on Application Startup.