### PR TITLE
Revert "Create background jobs on application startup"

### DIFF
--- a/config/initializers/create_background_jobs.rb
+++ b/config/initializers/create_background_jobs.rb
@@ -1,4 +1,0 @@
-# Create all Rufus Scheduler Jobs for active checks on Application Start
-Check.active.each do |check|
-  check.create_job
-end


### PR DESCRIPTION
Reverts brotandgames/ciao#7

Initializers are loaded when executing rake tasks so we have to find a better solution.
Until then one can use /checks/admin or the REST API endpoint to recreate checks.

cc @gnomus  

````
$ rake db:create
rake aborted!
ActiveRecord::StatementInvalid: Could not find table 'checks'
/Users/bojan/projects/ciao/app/models/check.rb:11:in `block in <class:Check>'
/Users/bojan/projects/ciao/config/initializers/create_background_jobs.rb:2:in `<main>'
/Users/bojan/projects/ciao/config/environment.rb:5:in `<main>'
Tasks: TOP => db:create => db:load_config => environment
(See full trace by running task with --trace)
````