### PR TITLE
Create background Jobs on Application Initialize

### DIFF
--- a/config/initializers/create_background_jobs.rb
+++ b/config/initializers/create_background_jobs.rb
@@ -1,0 +1,7 @@
+# Create all Rufus Scheduler Jobs for active checks on Application Start
+# Prevent the initializer to be run during rake tasks
+if defined?(Rails::Server) && ActiveRecord::Base.connection.table_exists?('checks')
+  Check.active.each do |check|
+    check.create_job
+  end
+end


### PR DESCRIPTION
Let's try that again :D

Unfortunately there seems to be no good Way to prevent an Initializer to run during a Rake Task.
Checking wether Rails::Server is defined was the most elegant Workaround I could find.

@brotandgames what do you think about this approach?