### PR TITLE
Add support for SMTP over SSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,10 @@ docker run \
   -e SMTP_PORT=587 \
   -e SMTP_DOMAIN=smtp.yourhost.com \
   -e SMTP_AUTHENTICATION=plain \
-  -e SMTP_ENABLE_STARTTLS_AUTO=auto \
+  -e SMTP_ENABLE_STARTTLS_AUTO="true" \
   -e SMTP_USERNAME=ciao \
   -e SMTP_PASSWORD="sensitive_password" \
+  -e SMTP_SSL="true" \
   -v /opt/ciao/data:/app/db/sqlite \
   brotandgames/ciao
 ````
@@ -76,9 +77,10 @@ services:
       - SMTP_PORT=587
       - SMTP_AUTHENTICATION=plain
       - SMTP_DOMAIN=smtp.yourhost.com
-      - SMTP_ENABLE_STARTTLS_AUTO=auto
+      - SMTP_ENABLE_STARTTLS_AUTO="true"
       - SMTP_USERNAME=ciao
       - SMTP_PASSWORD="sensitive_password"
+      - SMTP_SSL="true"
     volumes:
       - /opt/ciao/data:/app/db/sqlite/
 ````
@@ -111,9 +113,10 @@ export SECRET_KEY_BASE="sensitive_secret_key_base" \
   SMTP_PORT=587 \
   SMTP_DOMAIN=smtp.yourhost.com \
   SMTP_AUTHENTICATION=plain \
-  SMTP_ENABLE_STARTTLS_AUTO=auto \
+  SMTP_ENABLE_STARTTLS_AUTO="true" \
   SMTP_USERNAME=ciao \
-  SMTP_PASSWORD="sensitive_password"
+  SMTP_PASSWORD="sensitive_password" \
+  SMTP_SSL="true"
 
 # Run start script - basically this is check SECRET_KEY_BASE, database init/migrate and rails server
 RAILS_ENV=production ./start.sh
@@ -222,9 +225,10 @@ dokku config:set --no-restart ciao \
   SMTP_PORT=587 \
   SMTP_DOMAIN=smtp.yourhost.com \
   SMTP_AUTHENTICATION=plain \
-  SMTP_ENABLE_STARTTLS_AUTO=auto \
+  SMTP_ENABLE_STARTTLS_AUTO="true" \
   SMTP_USERNAME=ciao \
-  SMTP_PASSWORD="sensitive_password"
+  SMTP_PASSWORD="sensitive_password" \
+  SMTP_SSL="true"
 ````
 
 Deploy ciao using your deployment method eg. [Dockerfile Deployment](http://dokku.viewdocs.io/dokku/deployment/methods/dockerfiles/), [Docker Image Deployment](http://dokku.viewdocs.io/dokku/deployment/methods/images/) etc.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -86,7 +86,8 @@ Rails.application.configure do
       authentication: ENV["SMTP_AUTHENTICATION"],
       enable_starttls_auto: ENV["SMTP_ENABLE_STARTTLS_AUTO"],
       user_name: ENV["SMTP_USERNAME"],
-      password: ENV["SMTP_PASSWORD"]
+      password: ENV["SMTP_PASSWORD"],
+      ssl: ActiveModel::Type::Boolean.new.cast(ENV["SMTP_SSL"])
     }
   end
 


### PR DESCRIPTION
I tried to run Ciao and integrate it with Sendgrid. It did work perfectly but I got `Timeout` errors when the `ActiveMailer` tried to communicate with Sendgrid SMTP server.

After some investigations, I found that I need to set `ssl: true` in `action_mailer.smtp_settings` to support SMTP over SSL which is required by Sendgrid and probably any other reliable and save SMTP server.

This PR will enable the configuration of the SMTP over SSL using `SMTP_SSL` environment variable. If this variable was set to any value other than `[false, 0, '0', 'f', 'F', 'false', 'FALSE', 'off', 'OFF']` then it will be considered `true`.

**PS: I have a Kubernetes config/setup that perfectly worked here ;) I'll open a PR tomorrow and start on a helm chart for it 🤞**