### PR TITLE
Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+sudo: false
+language: ruby
+cache: bundler
+rvm:
+  - 2.6.3
+before_install: gem install bundler -v 2.0.1
+script:
+  - bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: ruby
 cache: bundler
 rvm:
   - 2.6.3
-before_install: gem install bundler -v 2.0.1
+before_install:
+  - gem install bundler -v 2.0.1
 script:
+  - yarn install --check-files
   - bundle exec rake

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Latest release](https://img.shields.io/github/release/brotandgames/ciao.svg)](https://github.com/brotandgames/ciao/releases/latest)
 [![Docker pulls](https://img.shields.io/docker/pulls/brotandgames/ciao.svg)](https://store.docker.com/community/images/brotandgames/ciao)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/brotandgames/ciao/master/LICENSE)
+[![Build Status](https://travis-ci.com/brotandgames/ciao.svg?branch=master)](https://travis-ci.com/brotandgames/ciao)
 
 **[ciao](https://www.brotandgames.com/ciao/)** checks HTTP(S) URL endpoints for a HTTP status code (or errors on the lower TCP stack) and sends an e-mail on status change.
 


### PR DESCRIPTION
Allow Travis CI to run tests and add a badge to the Github index to show tests status (passes/fails).

Git repo owner @brotandgames will need to give Travis access to automatically set up the webhooks and the process. This PR is to only set up the files needed to instruct Travis on how to build the test suite and to add Travis CI badge to README.md.

Example run:
https://travis-ci.com/tareksamni/ciao/builds/120923139