### PR TITLE
Add Feature: Load checks from json or yaml file

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,9 @@ Metrics/CyclomaticComplexity:
 Metrics/MethodLength:
   Enabled: false
 
+Metrics/ClassLength:
+  Enabled: false
+
 Metrics/PerceivedComplexity:
   Enabled: false
 

--- a/app/controllers/checks_controller.rb
+++ b/app/controllers/checks_controller.rb
@@ -144,7 +144,7 @@ class ChecksController < ApplicationController
       end
     else
       Rails.logger.info 'load_from_file CIAO_CHECKS_LOAD_FROM_FILE not set'
-      errors << 'CIAO_CHECKS_LOAD_FROM_FILE_not_set'
+      errors << 'not_configured'
     end
 
     Rails.logger.info "load_from_file Database conn. pool stat: #{ActiveRecord::Base.connection_pool.stat}"

--- a/app/controllers/checks_controller.rb
+++ b/app/controllers/checks_controller.rb
@@ -124,9 +124,9 @@ class ChecksController < ApplicationController
       file_path = ENV.fetch('CIAO_CHECKS_LOAD_FROM_FILE', '')
       accepted_file_exts = ['.json', '.yaml', '.yml']
       file_ext = File.extname(file_path)
-      if File.exists?(file_path) && accepted_file_exts.include?(file_ext)
+      if File.exist?(file_path) && accepted_file_exts.include?(file_ext)
         if ['.yaml', '.yml'].include?(file_ext)
-          Rails.logger.info "load_from_file Detected y[a]ml file"
+          Rails.logger.info 'load_from_file Detected y[a]ml file'
           input_json = JSON.parse(YAML.load_file(file_path).to_json)
         else
           input_json = JSON.parse(File.read(file_path))
@@ -135,16 +135,16 @@ class ChecksController < ApplicationController
           Check.bulk_load(input_json)
         else
           Rails.logger.info "load_from_file Found no checks in #{file_path}"
-          errors << "found_no_checks"
+          errors << 'found_no_checks'
         end
       else
         Rails.logger.info "load_from_file File #{file_path} doesn't exist or"
         Rails.logger.info "load_from_file has not accepted file extension (#{accepted_file_exts})"
-        errors << "file_not_exists_or_ext_not_accepted"
+        errors << 'file_not_exists_or_ext_not_accepted'
       end
     else
-      Rails.logger.info "load_from_file CIAO_CHECKS_LOAD_FROM_FILE not set"
-      errors << "CIAO_CHECKS_LOAD_FROM_FILE_not_set"
+      Rails.logger.info 'load_from_file CIAO_CHECKS_LOAD_FROM_FILE not set'
+      errors << 'CIAO_CHECKS_LOAD_FROM_FILE_not_set'
     end
 
     Rails.logger.info "load_from_file Database conn. pool stat: #{ActiveRecord::Base.connection_pool.stat}"
@@ -152,7 +152,7 @@ class ChecksController < ApplicationController
       if errors.any?
         format.html do
           redirect_to checks_url,
-                      notice: "Checks not loaded from file: " + errors.join(',')
+                      notice: 'Checks not loaded from file: ' + errors.join(',')
         end
         format.json do
           render json: errors, status: :unprocessable_entity

--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -114,4 +114,19 @@ class Check < ApplicationRecord
       create_job
     end
   end
+
+  def self.bulk_load(json_array)
+    Rails.logger.info "bulk_load Found #{json_array.length} check(s)"
+    json_array.each.with_index(1) do |check, i|
+      Rails.logger.info "bulk_load Check #{i} load: #{check}"
+      c = Check.new(check)
+      if c.save
+        Rails.logger.info "bulk_load Check #{i} loaded"
+      else
+        Rails.logger.info "bulk_load Check #{i} could not be loaded: #{check}"
+        Rails.logger.info "bulk_load Check #{i} errors: #{c.errors.messages}"
+      end
+    end
+
+  end
 end

--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -98,6 +98,20 @@ class Check < ApplicationRecord
     end
   end
 
+  def self.bulk_load(json_array)
+    Rails.logger.info "bulk_load Found #{json_array.length} check(s)"
+    json_array.each.with_index(1) do |check, i|
+      Rails.logger.info "bulk_load Check #{i} load: #{check}"
+      c = Check.new(check)
+      if c.save
+        Rails.logger.info "bulk_load Check #{i} loaded"
+      else
+        Rails.logger.info "bulk_load Check #{i} could not be loaded: #{check}"
+        Rails.logger.info "bulk_load Check #{i} errors: #{c.errors.messages}"
+      end
+    end
+  end
+
   private
 
   def update_routine
@@ -113,20 +127,5 @@ class Check < ApplicationRecord
       unschedule_job
       create_job
     end
-  end
-
-  def self.bulk_load(json_array)
-    Rails.logger.info "bulk_load Found #{json_array.length} check(s)"
-    json_array.each.with_index(1) do |check, i|
-      Rails.logger.info "bulk_load Check #{i} load: #{check}"
-      c = Check.new(check)
-      if c.save
-        Rails.logger.info "bulk_load Check #{i} loaded"
-      else
-        Rails.logger.info "bulk_load Check #{i} could not be loaded: #{check}"
-        Rails.logger.info "bulk_load Check #{i} errors: #{c.errors.messages}"
-      end
-    end
-
   end
 end

--- a/app/views/checks/admin.html.erb
+++ b/app/views/checks/admin.html.erb
@@ -15,7 +15,7 @@
         </h4>
         <p>File: <code><%= ENV.fetch('CIAO_CHECKS_LOAD_FROM_FILE', 'not configured') %></code></p>
         <p>
-          <%= link_to '<i class="fe fe-file"></i> Load from file'.html_safe, load_from_file_checks_path, class: 'btn btn-info' %>
+          <%= link_to '<i class="fe fe-file"></i> Load from file'.html_safe, load_from_file_checks_path, class: 'btn btn-warning', data: { confirm: 'Are you sure?' } %>
         </p>
         <p>
           It can be also accomplished using the REST API endpoint:

--- a/app/views/checks/admin.html.erb
+++ b/app/views/checks/admin.html.erb
@@ -13,7 +13,7 @@
         <h4>
           Load checks from file
         </h4>
-        <p>CIAO_CHECKS_LOAD_FROM_FILE: <code><%= ENV.fetch('CIAO_CHECKS_LOAD_FROM_FILE', 'not configured') %></code></p>
+        <p>File: <code><%= ENV.fetch('CIAO_CHECKS_LOAD_FROM_FILE', 'not configured') %></code></p>
         <p>
           <%= link_to '<i class="fe fe-file"></i> Load from file'.html_safe, load_from_file_checks_path, class: 'btn btn-info' %>
         </p>

--- a/app/views/checks/admin.html.erb
+++ b/app/views/checks/admin.html.erb
@@ -4,10 +4,28 @@
       <div class="card-header">
         <h3 class="card-title">Administration</h3>
         <div class="card-options">
+           <span id="notice"><%= notice %></span>
+           <%= link_to 'Documentation',
+             'https://github.com/brotandgames/ciao', class: 'btn btn-info btn-sm ml-1'%>
         </div>
       </div>
       <div class="card-body">
-      	<div id="notice"><%= notice %></div>
+        <h4>
+          Load checks from file
+        </h4>
+        <p>CIAO_CHECKS_LOAD_FROM_FILE: <code><%= ENV.fetch('CIAO_CHECKS_LOAD_FROM_FILE', 'not configured') %></code></p>
+        <p>
+          <%= link_to '<i class="fe fe-file"></i> Load from file'.html_safe, load_from_file_checks_path, class: 'btn btn-info' %>
+        </p>
+        <p>
+          It can be also accomplished using the REST API endpoint:
+        </p>
+        <p>
+          <code>
+            curl -X GET -H "Content-type: application/json" /checks/load-from-file.json
+          </code>
+        </p>
+        <hr />
         <h4>
           Recreate all scheduled background jobs of active checks
         </h4>
@@ -45,6 +63,7 @@
         <p><strong>HTTP Basic auth username:</strong> <code><%= ENV.fetch('BASIC_AUTH_USERNAME', 'not configured') %></code></p>
         <p><strong>Prometheus enabled:</strong> <code><%= ENV.fetch('PROMETHEUS_ENABLED', 'not configured') %></code></p>
         <p><strong>Prometheus HTTP Basic auth username:</strong> <code><%= ENV.fetch('PROMETHEUS_BASIC_AUTH_USERNAME', 'not configured') %></code></p>
+        <p><strong>Checks load from file:</strong> <code><%= ENV.fetch('CIAO_CHECKS_LOAD_FROM_FILE', 'not configured') %></code></p>
         <p>
           <span class="badge badge-dark %>">
           Database

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
     get 'job', to: 'checks#job'
     get 'jobs/recreate', to: 'checks#jobs_recreate', on: :collection
     get 'admin', to: 'checks#admin', on: :collection
+    get 'load-from-file', to: 'checks#load_from_file', on: :collection
   end
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/test/fixtures/files/checks_input.json
+++ b/test/fixtures/files/checks_input.json
@@ -1,0 +1,27 @@
+[
+    {
+        "active": true,
+        "name": "brotandgames.com",
+        "cron": "* * * * *",
+        "url": "https://brotandgames.com"
+    },
+    {
+        "active": true,
+        "name": "kubernete.sh",
+        "cron": "*/15 * * * *",
+        "url": "https://kubernete.sh"
+    }
+    ,
+    {
+        "active": true,
+        "name": "url fail",
+        "cron": "* * * * *",
+        "url": "htps://kubernete.sh"
+    },
+    {
+        "active": true,
+        "name": "cron fail",
+        "cron": "*12 * * * *",
+        "url": "https://kubernete.sh"
+    }
+]

--- a/test/fixtures/files/checks_input.yaml
+++ b/test/fixtures/files/checks_input.yaml
@@ -1,0 +1,17 @@
+---
+- active: true
+  name: brotandgames.com
+  cron: "* * * * *"
+  url: https://brotandgames.com
+- active: true
+  name: kubernete.sh
+  cron: "*/15 * * * *"
+  url: https://kubernete.sh
+- active: true
+  name: url fail
+  cron: "* * * * *"
+  url: htps://kubernete.sh
+- active: true
+  name: cron fail
+  cron: "*12 * * * *"
+  url: https://kubernete.sh


### PR DESCRIPTION
If you define `CIAO_CHECKS_LOAD_FROM_FILE` ENV variable by setting it to a valid file path like

* `$file_path.[json|yaml|yml]` eg. `CIAO_CHECKS_LOAD_FROM_FILE="/data/ciao/checks_input.json"` *(file must be available in filesystem or docker/kubernetes volume)*, 

you can load checks from this file by 

* visiting `/checks/admin`in the Web UI and using the *Load from file* button **or**
* calling the JSON endpoint like `curl -X GET -H "Content-type: application/json" /checks/load-from-file.json`.

Example files

`checks_input.json`

````json
[
    {
        "active": true,
        "name": "brotandgames.com",
        "cron": "* * * * *",
        "url": "https://brotandgames.com"
    },
    {
        "active": true,
        "name": "kubernete.sh",
        "cron": "*/15 * * * *",
        "url": "https://kubernete.sh"
    }
]
````

`checks_input.yaml`

````yaml
---
- active: true
  name: brotandgames.com
  cron: "* * * * *"
  url: https://brotandgames.com
- active: true
  name: kubernete.sh
  cron: "*/15 * * * *"
  url: https://kubernete.sh
````