### PR TITLE
Make Dockerfile buildable for ARM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,13 +23,15 @@ RUN set -x \
     && rm -rf \
         /usr/local/bundle/cache/*.gem \
         /usr/local/bundle/gems/**/*.c \
-        /usr/local/bundle/gems/**/*.o \
-    && apk del .build-deps
+        /usr/local/bundle/gems/**/*.o
 
 COPY package.json yarn.lock /app/
+
 RUN set -x \
     && yarn install \
     && rm -rf /tmp/*
+
+RUN apk del .build-deps
 
 COPY . ./
 


### PR DESCRIPTION
I tried building the Dockerfile for ARM and ran into the issue that `yarn install` needs python2 which gets deleted by `RUN apk del .build-deps` so I moved that lower in the Dockerfile.