### PR TITLE
Add support for PostgreSQL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ RUN set -x \
         build-base \
         libxml2-dev \
         libxslt-dev \
+        postgresql-client \
+        postgresql-dev \
     && gem install bundler \
     && bundle install --without development:test --jobs 20 -j"$(nproc)" --retry 3 \
     # Remove unneeded files (cached *.gem, *.o, *.c)
@@ -39,7 +41,7 @@ COPY . ./
 # Added xz-libs (should be only build-dep) because nokogiri needs liblzma.so.5
 # during rake tasks (eg. assets-precompile)
 RUN set -x \
-    && apk add --no-cache xz-libs \
+    && apk add --no-cache xz-libs postgresql-client \
     && SECRET_KEY_BASE=foo bundle exec rake assets:precompile \
     # Remove folders not needed in resulting image
     && rm -rf \

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ ruby '2.6.5'
 gem 'rails', '6.1.4'
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3', '~> 1.4'
+gem 'pg', '~> 1.2.3'
 # Use Puma as the app server
 gem 'puma', '~> 4.3'
 # Use SCSS for stylesheets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,6 +134,7 @@ GEM
     parallel (1.17.0)
     parser (2.6.4.1)
       ast (~> 2.4.0)
+    pg (1.2.3)
     popper_js (1.14.5)
     prometheus-client (0.9.0)
       quantile (~> 0.2.1)
@@ -286,6 +287,7 @@ DEPENDENCIES
   letter_opener
   listen (>= 3.0.5, < 3.2)
   mocha
+  pg (~> 1.2.3)
   prometheus-client
   puma (~> 4.3)
   rails (= 6.1.4)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ ciao is configured via ENVIRONMENT variables following the [12-factor app method
 - Check [Webhook Configuration](webhook_configuration.md) for instructions how to send (webhook) notifications to RocketChat, Slack etc. (since version 1.4.0)
 - You can enable HTTP Basic auth for ciao by defining `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD` eg. `BASIC_AUTH_USERNAME="ciao-admin"` and `BASIC_AUTH_PASSWORD="sensitive_password"` (since version 1.3.0)
 - You can enable a Prometheus Metrics endpoint served under `/metrics` by setting `PROMETHEUS_ENABLED=true` - furthermore you can enable HTTP Basic auth for this endpoint by defining `PROMETHEUS_BASIC_AUTH_USERNAME="ciao-metrics"` and `PROMETHEUS_BASIC_AUTH_PASSWORD="sensitive_password"` (since version 1.5.0)
+- You can optionally use an external PostgreSQL database by setting `DATABASE_ADAPTER=postgresql` and `DATABASE_URL=postgres://USERNAME:PASSWORD@HOST:PORT/DB_NAME`
 
 ## Install
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,7 +5,7 @@
 #   gem 'sqlite3'
 #
 default: &default
-  adapter: sqlite3
+  adapter: <%= ENV.fetch("DATABASE_ADAPTER") { "sqlite3" } %>
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 10 } %>
   timeout: 5000
 
@@ -22,4 +22,5 @@ test:
 
 production:
   <<: *default
-  database: db/sqlite/production.sqlite3
+  database: <%= ENV.fetch("DATABASE_NAME") { "db/sqlite/production.sqlite3" } %>
+  url: <%= ENV["DATABASE_URL"] %>


### PR DESCRIPTION
Hi there! I do love the simplicity of Ciao and its "no external dependencies" mantra but unfortunately, on many hosting providers, it's impossible to ensure the database will be persisted across restarts/updates. I made a small update that allows to override the default database adapter and connect to a PostgreSQL database in such cases.

Hope this is useful and happy Hacktoberfest :)